### PR TITLE
adding in docker-compose capability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM axiom/docker-erddap:latest
+
+EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,0 @@
-FROM axiom/docker-erddap:latest
-
-EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ docker run --rm \
   -v /tmp/:/usr/local/tomcat/temp/ \
  axiom/docker-erddap:1.82
 ```
+or
+```
+docker-compose up -d
+```
 
 After startup, go to http://localhost:8080/erddap/index.html 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,7 @@ version: '2'
 services:
   erddap:
     container_name: "erddap_test"
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: axiom/docker-erddap:latest
     restart: unless-stopped
     ports:
       - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '2'
+services:
+  erddap:
+    container_name: "erddap_test"
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    volumes:
+      - "${PWD}/erddap/conf/setenv.sh:/usr/local/tomcat/bin/setenv.sh"
+      - "${PWD}/erddap/conf/robots.txt:/usr/local/tomcat/webapps/ROOT/robots.txt"
+      - "${PWD}/erddap/content:/usr/local/tomcat/content/erddap"
+      - "${PWD}/erddap/data:/erddapData"
+      - "${PWD}/datasets:/datasets"
+      - "/tmp/:/usr/local/tomcat/temp/"


### PR DESCRIPTION
Added the docker-compose capability to make it easier to deploy erddap locally. Just use
```bash
docker-compose up -d
```
instead of the `docker run ` command.
Might be helpful for others.