### PR TITLE
Updated font-family to built-in DejaVu Sans

### DIFF
--- a/erddap/content/setup.xml
+++ b/erddap/content/setup.xml
@@ -374,7 +374,7 @@ At ERD, we use "Bitstream Vera Sans"
   http://coastwatch.pfeg.noaa.gov/erddap/download/BitstreamVeraSans.zip
   and unzip the files into [javaHome]/jre/lib/fonts so Java sees them.
 -->
-<fontFamily>Bitstream Vera Sans</fontFamily>
+<fontFamily>DejaVu Sans</fontFamily>
 
 <!-- When possible (and it isn't always possible), ERDDAP breaks source data requests
 into chunks to conserve memory. See the description of these tags in messages.xml.


### PR DESCRIPTION
Updated the `font-family` to the built-in DejaVu Sans. This corrects an issue which was preventing ERDDAP from starting. 

See relevant issue here: [https://github.com/axiom-data-science/docker-erddap/pull/12](https://github.com/axiom-data-science/docker-erddap/pull/12)