### PR TITLE
Include nco-yaml representations of datasets (and script)

### DIFF
--- a/DasDds.sh
+++ b/DasDds.sh
@@ -3,6 +3,6 @@ docker run --rm -it \
   -v "$(pwd)/datasets:/datasets" \
   -v "$(pwd)/logs:/erddapData/logs" \
   -v "$(pwd)/erddap/content:/usr/local/tomcat/content/erddap" \
-  axiom/docker-erddap:latest \
+  -e ERDDAP_flagKeyKey=flag-key-not-needed-for-dasdds \
+  axiom/docker-erddap:2.23-jdk17-openjdk \
   bash -c "cd webapps/erddap/WEB-INF/ && bash DasDds.sh"
-  

--- a/README.md
+++ b/README.md
@@ -9,3 +9,13 @@ Uses the [ERDDAP Docker image](https://github.com/axiom-data-science/docker-erdd
 You can view this setup live at <https://standards.sensors.ioos.us/erddap/index.html>.
 
 Documentation can be found at <https://ioos.github.io/erddap-gold-standard/>.
+
+# Datasets
+
+The gold standard datasets are
+[IOOS Metadata Profile](https://ioos.github.io/ioos-metadata/ioos-metadata-profile-v1-2.html)
+compliant NetCDF files stored in the `./datasets` directory.
+
+Yaml text representations of the NetCDF metadata (based on nco-json output) are also
+included for easy discoverability and access in the `./datasets-yml` directory.
+See the `./datasets-yml/datasets.yml.sh` script for more details.

--- a/datasets-yml/datasets.yml.sh
+++ b/datasets-yml/datasets.yml.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# generate nco-yaml (readable yaml representation of nco-json)
+# representations of gold standard datasets
+# usage:
+#   generate nco-yaml files from datasets/*.nc files:
+#     ./datasets-yml/datasets.yml.sh
+#   check that nco-yaml files are up-to-date:
+#     ./datasets-yml/datasets.yml.sh -c
+#
+# requirements:
+#   ncks/nco (https://nco.sourceforge.net/nco.html)
+#   yq v4 (https://mikefarah.gitbook.io/yq/)
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "$DIR"
+
+CHECK=0
+while getopts ":c" opt; do
+  case ${opt} in
+    c )
+      CHECK=1
+      ;;
+    \? )
+      echo "Invalid option: $OPTARG" 1>&2
+      ;;
+    : )
+      echo "Invalid option: $OPTARG requires an argument" 1>&2
+      ;;
+  esac
+done
+shift $((OPTIND -1))
+
+# check for required commands
+for c in ncks yq; do
+  if ! command -v $c &> /dev/null; then
+    echo "Command $c is required but missing" >&2
+    exit 1
+  fi
+done
+
+# write nco-yaml for each dataset
+for d in ../datasets/*.nc; do
+  YML="$(basename $d).yml"
+  NCO_YAML="$(ncks -mM --json "$d" | yq -p=json)"
+  if [ "$CHECK" == "1" ]; then
+    # if in check mode, make sure yaml files exist for all datasets
+    # and don't differ from generated output
+    if [ ! -f "$YML" ]; then
+      echo "$d doesn't have an existing yml file">&2
+      exit 1
+    fi
+    NC_CHECKSUM=$(echo -n "$NCO_YAML" | md5sum | cut -f1 -d\ )
+    YAML_CHECKSUM=$(md5sum $YML | cut -f1 -d\ )
+    if [ "$NC_CHECKSUM" != "$YAML_CHECKSUM" ]; then
+      echo "$d metadata checksum differs from existing yaml file">&2
+      exit 1
+    fi
+  else
+    # if not in check mode, write nco-yaml
+    echo -n "$NCO_YAML" > "$YML"
+  fi
+done

--- a/datasets-yml/edu_calpoly_marine_morro_bay_met.nc.yml
+++ b/datasets-yml/edu_calpoly_marine_morro_bay_met.nc.yml
@@ -1,0 +1,333 @@
+dimensions:
+  time: 40970
+variables:
+  air_pressure:
+    shape:
+      - time
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 40794
+        - 1
+      actual_range:
+        - 990.38
+        - 1031.56
+      id: "1000289"
+      ioos_category: Other
+      long_name: Barometric Pressure
+      platform: station
+      standard_name: air_pressure
+      standard_name_url: http://mmisw.org/ont/cf/parameter/air_pressure
+      units: millibars
+      coordinates: time z longitude latitude
+  air_temperature:
+    shape:
+      - time
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 40794
+        - 1
+      actual_range:
+        - -9.35
+        - 34.03
+      id: "1000293"
+      ioos_category: Other
+      long_name: Air Temperature
+      platform: station
+      standard_name: air_temperature
+      standard_name_url: http://mmisw.org/ont/cf/parameter/air_temperature
+      units: degree_Celsius
+      coordinates: time z longitude latitude
+  crs:
+    type: int
+  dew_point_temperature:
+    shape:
+      - time
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 40794
+        - 1
+      actual_range:
+        - -19.15
+        - 34.03
+      id: "1000290"
+      ioos_category: Other
+      long_name: Dew Point
+      platform: station
+      standard_name: dew_point_temperature
+      standard_name_url: http://mmisw.org/ont/cf/parameter/dew_point_temperature
+      units: degree_Celsius
+      coordinates: time z longitude latitude
+  latitude:
+    type: double
+    attributes:
+      axis: Y
+      _CoordinateAxisType: Lat
+      actual_range:
+        - 35.33382
+        - 35.33382
+      ioos_category: Location
+      long_name: Latitude
+      standard_name: latitude
+      units: degrees_north
+  longitude:
+    type: double
+    attributes:
+      axis: X
+      _CoordinateAxisType: Lon
+      actual_range:
+        - -120.84725
+        - -120.84725
+      ioos_category: Location
+      long_name: Longitude
+      standard_name: longitude
+      units: degrees_east
+  lwe_precipitation_rate_cm_time__sum_over_pt2m:
+    shape:
+      - time
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 40794
+        - 1
+      actual_range:
+        - 0
+        - 21.5
+      cell_methods: 'time: sum'
+      id: "1000215"
+      interval: PT2M
+      ioos_category: Other
+      long_name: Precipitation (increment)
+      platform: station
+      standard_name: lwe_precipitation_rate
+      standard_name_url: http://mmisw.org/ont/cf/parameter/lwe_precipitation_rate
+      units: mm
+      coordinates: time z longitude latitude
+  relative_humidity:
+    shape:
+      - time
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 40794
+        - 1
+      actual_range:
+        - 0
+        - 100
+      id: "1000291"
+      ioos_category: Other
+      long_name: Relative Humidity
+      platform: station
+      standard_name: relative_humidity
+      standard_name_url: http://mmisw.org/ont/cf/parameter/relative_humidity
+      units: '%'
+      coordinates: time z longitude latitude
+  solar_irradiance:
+    shape:
+      - time
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 40794
+        - 1
+      actual_range:
+        - 0
+        - 892.81
+      id: "1000292"
+      ioos_category: Other
+      long_name: Solar Radiation
+      platform: station
+      standard_name: solar_irradiance
+      standard_name_url: http://mmisw.org/ont/cf/parameter/solar_irradiance
+      units: W.m-2
+      coordinates: time z longitude latitude
+  station:
+    type: string
+    attributes:
+      cf_role: timeseries_id
+      long_name: Morro Bay - BS1 MET
+      _Encoding: ISO-8859-1
+      ioos_category: Identifier
+      ioos_code: urn:ioos:station:com.axiomdatascience:57163
+      short_name: edu_calpoly_marine_morro_bay_met
+      type: fixed
+  time:
+    shape:
+      - time
+    type: double
+    attributes:
+      units: seconds since 1970-01-01T00:00:00Z
+      standard_name: time
+      axis: T
+      _ChunkSizes: 40794
+      _CoordinateAxisType: Time
+      actual_range:
+        - 1.4542848e+09
+        - 1.571962037e+09
+      calendar: gregorian
+      ioos_category: Time
+      long_name: Time
+      time_origin: 01-JAN-1970 00:00:00
+  wind_chill_temperature:
+    shape:
+      - time
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 40794
+        - 1
+      actual_range:
+        - -19.15
+        - 34.03
+      id: "1000294"
+      ioos_category: Other
+      long_name: Wind Chill
+      platform: station
+      standard_name: wind_chill_temperature
+      standard_name_url: http://mmisw.org/ont/unknown/parameter/wind_chill_temperature
+      units: degree_Celsius
+      coordinates: time z longitude latitude
+  wind_from_direction:
+    shape:
+      - time
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 40794
+        - 1
+      actual_range:
+        - 0.04
+        - 359.88
+      id: "1000295"
+      ioos_category: Other
+      long_name: Wind From Direction
+      platform: station
+      standard_name: wind_from_direction
+      standard_name_url: http://mmisw.org/ont/cf/parameter/wind_from_direction
+      units: degrees
+      coordinates: time z longitude latitude
+  wind_speed:
+    shape:
+      - time
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 40794
+        - 1
+      actual_range:
+        - 0
+        - 18.01
+      id: "1000296"
+      ioos_category: Other
+      long_name: Wind Speed
+      platform: station
+      standard_name: wind_speed
+      standard_name_url: http://mmisw.org/ont/cf/parameter/wind_speed
+      units: m.s-1
+      coordinates: time z longitude latitude
+  z:
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      axis: Z
+      _ChunkSizes: 1
+      _CoordinateAxisType: Height
+      _CoordinateZisPositive: up
+      actual_range:
+        - 0
+        - 0
+      ioos_category: Location
+      least_significant_digit: 2
+      long_name: Altitude
+      positive: up
+      standard_name: altitude
+      units: m
+attributes:
+  Conventions: IOOS-1.2, CF-1.6, ACDD-1.3
+  date_created: "2020-04-22T22:29:00Z"
+  featureType: TimeSeries
+  cdm_data_type: TimeSeries
+  acknowledgment: Data collection was supported by multiple awards to California Polytechnic State University and an award from NOAA's Integrated Observing System to the Central and Northern California Ocean Observing System at the Monterey Bay Aquarium Research Institute (NA11NOS0120032).
+  cdm_timeseries_variables: station,longitude,latitude
+  comment: Data produced by Ryan Walter with partial funding from CeNCOOS (cencoos_communicatons@mbari.org)
+  contributor_email: cencoos_communications@mbari.org,feedback@axiomdatascience.com
+  contributor_name: Central & Northern California Ocean Observing System (CeNCOOS),Axiom Data Science
+  contributor_role: contributor,processor
+  contributor_role_vocabulary: NERC
+  contributor_url: http://cencoos.org/,https://www.axiomdatascience.com
+  coverage_content_type: physicalMeasurement
+  creator_country: USA
+  creator_email: rkwalter@calpoly.edu
+  creator_institution: California Polytechnic State Univeristy, San Luis Obispo
+  creator_name: Ryan Walter
+  creator_role: pi
+  creator_sector: academic
+  creator_type: person
+  creator_url: http://www.marine.calpoly.edu
+  Easternmost_Easting: -120.84725
+  geospatial_lat_max: 35.33382
+  geospatial_lat_min: 35.33382
+  geospatial_lat_units: degrees_north
+  geospatial_lon_max: -120.84725
+  geospatial_lon_min: -120.84725
+  geospatial_lon_units: degrees_east
+  geospatial_vertical_positive: up
+  geospatial_vertical_units: m
+  history: |-
+    Downloaded from California Polytechnic State University, Center for Coastal Marine Sciences at http://cpool1.marine.calpoly.edu/cpool/CCMS_MorroBay/
+    2020-04-22T22:22:19Z http://cpool1.marine.calpoly.edu/cpool/CCMS_MorroBay/
+    2020-04-22T22:22:19Z http://erddap.stage.sensors.axds.co/erddap/tabledap/edu_calpoly_marine_morro_bay_met.nc
+  infoUrl: https://sensors.ioos.us/#metadata/57163/station
+  institution: California Polytechnic State Univeristy, San Luis Obispo
+  instrument: Nova Lynx 100
+  ISO_Topic_Categories: Oceans
+  keywords: Earth Science > Oceans
+  keywords_vocabulary: GCMD Earth Science Keywords. Version 5.3.3
+  license: |-
+    The data may be used and redistributed for free but is not intended
+    for legal use, since it may contain inaccuracies. Neither the data
+    Contributor, ERD, NOAA, nor the United States Government, nor any
+    of their employees or contractors, makes any warranty, express or
+    implied, including warranties of merchantability and fitness for a
+    particular purpose, or assumes any legal liability for the accuracy,
+    completeness, or usefulness, of this information.
+  metadata_conventions: CF-1.6,ACDD-1.3
+  metadata_link: http://www.marine.calpoly.edu
+  Northernmost_Northing: 35.33382
+  platform_name: Morro Bay - BS1 MET
+  platform_vocabulary: http://mmisw.org/ont/ioos/platform
+  processing_level: Level 2
+  program: CeNCOOS
+  project: CeNCOOS
+  publisher_country: USA
+  publisher_email: cencoos_communicatons@mbari.org
+  publisher_institution: California Polytechnic State University, Center for Coastal Marine Sciences
+  publisher_name: CeNCOOS
+  publisher_sector: academic
+  publisher_type: institution
+  publisher_url: http://www.cencoos.org
+  references: http://www.slosea.org/about/dash.php,http://cpool1.marine.calpoly.edu/cpool/CCMS_MorroBay/,https://www.cencoos.org/data/shore/morro,
+  sea_name: NE Pacific
+  source: Station mounded on a large tripod resting on the sea floor.
+  sourceUrl: http://cpool1.marine.calpoly.edu/cpool/CCMS_MorroBay/
+  Southernmost_Northing: 35.33382
+  standard_name_vocabulary: CF Standard Name Table v72
+  summary: 'Morro Bay BS1 Met station is located in the back of Morro Bay, CA and owned by California Polytechnic State University of San Luis Obispo. The station is mounted on a large tripod, resting on the seafloor. A Nova Lynx 100 Weather Station is fixed at 3 meters above MLLW to a pole extending from the tripod and reports the following in near real-time: wind speed, wind direction, air temperature, barometric pressure, precipitation, relative humidity, and solar radiation. The instrument is maintained and operated by San Luis Obispo Science and Ecosystem Alliance (SLOSEA), a part of the Cal Poly Center for Coastal Marine Sciences.'
+  time_coverage_end: "2019-10-25T00:07:17Z"
+  time_coverage_start: "2016-02-01T00:00:00Z"
+  title: CeNCOOS met monitoring at Morro Bay (BS1).
+  Westernmost_Easting: -120.84725
+  id: bs1-met
+  naming_authority: edu.calpoly.marine
+  platform: morro-bay-bs1-met

--- a/datasets-yml/org_cormp_cap2.nc.yml
+++ b/datasets-yml/org_cormp_cap2.nc.yml
@@ -1,0 +1,687 @@
+dimensions:
+  time: 7240
+variables:
+  air_pressure:
+    shape:
+      - time
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 7240
+        - 1
+      actual_range:
+        - 0
+        - 1049.385
+      ancillary_variables: air_pressure_qc_agg air_pressure_qc_tests
+      id: "1000314"
+      ioos_category: Other
+      long_name: Barometric Pressure
+      platform: station
+      standard_name: air_pressure
+      standard_name_url: http://mmisw.org/ont/cf/parameter/air_pressure
+      units: millibars
+      coordinates: time z longitude latitude
+  air_pressure_qc_agg:
+    shape:
+      - time
+    type: int
+    attributes:
+      _FillValue: -9999
+      _ChunkSizes:
+        - 7240
+        - 1
+      _Unsigned: "true"
+      actual_range:
+        - 1
+        - 4
+      flag_meanings: PASS NOT_EVALUATED SUSPECT FAIL MISSING
+      flag_values:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 9
+      ioos_category: Other
+      long_name: Barometric Pressure QARTOD Aggregate Quality Flag
+      references: http://services.cormp.org/quality.php
+      standard_name: aggregate_quality_flag
+      coordinates: time z longitude latitude
+  air_pressure_qc_tests:
+    shape:
+      - time
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 7240
+        - 1
+      _Unsigned: "true"
+      comment: '11-character string with results of individual QARTOD tests. 1: Gap Test, 2: Syntax Test, 3: Location Test, 4: Gross Range Test, 5: Climatology Test, 6: Spike Test, 7: Rate of Change Test, 8: Flat-line Test, 9: Multi-variate Test, 10: Attenuated Signal Test, 11: Neighbor Test'
+      flag_meanings: PASS NOT_EVALUATED SUSPECT FAIL MISSING
+      flag_values:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 9
+      ioos_category: Other
+      long_name: Barometric Pressure QARTOD Individual Tests
+      references: http://services.cormp.org/quality.php
+      standard_name: air_pressure quality_flag
+      coordinates: time z longitude latitude
+  air_temperature:
+    shape:
+      - time
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 7240
+        - 1
+      actual_range:
+        - 0
+        - 29.53
+      ancillary_variables: air_temperature_qc_agg air_temperature_qc_tests
+      id: "1000315"
+      ioos_category: Other
+      long_name: Air Temperature
+      platform: station
+      standard_name: air_temperature
+      standard_name_url: http://mmisw.org/ont/cf/parameter/air_temperature
+      units: degree_Celsius
+      coordinates: time z longitude latitude
+  air_temperature_qc_agg:
+    shape:
+      - time
+    type: int
+    attributes:
+      _FillValue: -9999
+      _ChunkSizes:
+        - 7240
+        - 1
+      _Unsigned: "true"
+      actual_range:
+        - 1
+        - 4
+      flag_meanings: PASS NOT_EVALUATED SUSPECT FAIL MISSING
+      flag_values:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 9
+      ioos_category: Other
+      long_name: Air Temperature QARTOD Aggregate Quality Flag
+      references: http://services.cormp.org/quality.php
+      standard_name: aggregate_quality_flag
+      coordinates: time z longitude latitude
+  air_temperature_qc_tests:
+    shape:
+      - time
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 7240
+        - 1
+      _Unsigned: "true"
+      comment: '11-character string with results of individual QARTOD tests. 1: Gap Test, 2: Syntax Test, 3: Location Test, 4: Gross Range Test, 5: Climatology Test, 6: Spike Test, 7: Rate of Change Test, 8: Flat-line Test, 9: Multi-variate Test, 10: Attenuated Signal Test, 11: Neighbor Test'
+      flag_meanings: PASS NOT_EVALUATED SUSPECT FAIL MISSING
+      flag_values:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 9
+      ioos_category: Other
+      long_name: Air Temperature QARTOD Individual Tests
+      references: http://services.cormp.org/quality.php
+      standard_name: air_temperature quality_flag
+      coordinates: time z longitude latitude
+  crs:
+    type: int
+  latitude:
+    type: double
+    attributes:
+      axis: Y
+      _CoordinateAxisType: Lat
+      actual_range:
+        - 32.8032
+        - 32.8032
+      ioos_category: Location
+      long_name: Latitude
+      standard_name: latitude
+      units: degrees_north
+  longitude:
+    type: double
+    attributes:
+      axis: X
+      _CoordinateAxisType: Lon
+      actual_range:
+        - -79.6204
+        - -79.6204
+      ioos_category: Location
+      long_name: Longitude
+      standard_name: longitude
+      units: degrees_east
+  relative_humidity:
+    shape:
+      - time
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 7240
+        - 1
+      actual_range:
+        - 0
+        - 100
+      ancillary_variables: relative_humidity_qc_agg relative_humidity_qc_tests
+      id: "1000316"
+      ioos_category: Other
+      long_name: Relative Humidity
+      platform: station
+      standard_name: relative_humidity
+      standard_name_url: http://mmisw.org/ont/cf/parameter/relative_humidity
+      units: '%'
+      coordinates: time z longitude latitude
+  relative_humidity_qc_agg:
+    shape:
+      - time
+    type: int
+    attributes:
+      _FillValue: -9999
+      _ChunkSizes:
+        - 7240
+        - 1
+      _Unsigned: "true"
+      actual_range:
+        - 1
+        - 4
+      flag_meanings: PASS NOT_EVALUATED SUSPECT FAIL MISSING
+      flag_values:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 9
+      ioos_category: Other
+      long_name: Relative Humidity QARTOD Aggregate Quality Flag
+      references: http://services.cormp.org/quality.php
+      standard_name: aggregate_quality_flag
+      coordinates: time z longitude latitude
+  relative_humidity_qc_tests:
+    shape:
+      - time
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 7240
+        - 1
+      _Unsigned: "true"
+      comment: '11-character string with results of individual QARTOD tests. 1: Gap Test, 2: Syntax Test, 3: Location Test, 4: Gross Range Test, 5: Climatology Test, 6: Spike Test, 7: Rate of Change Test, 8: Flat-line Test, 9: Multi-variate Test, 10: Attenuated Signal Test, 11: Neighbor Test'
+      flag_meanings: PASS NOT_EVALUATED SUSPECT FAIL MISSING
+      flag_values:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 9
+      ioos_category: Other
+      long_name: Relative Humidity QARTOD Individual Tests
+      references: http://services.cormp.org/quality.php
+      standard_name: relative_humidity quality_flag
+      coordinates: time z longitude latitude
+  sea_water_practical_salinity:
+    shape:
+      - time
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 7240
+        - 1
+      actual_range:
+        - 5.164
+        - 35.71
+      ancillary_variables: sea_water_practical_salinity_qc_agg sea_water_practical_salinity_qc_tests
+      id: "1000317"
+      ioos_category: Other
+      long_name: Salinity
+      platform: station
+      standard_name: sea_water_practical_salinity
+      standard_name_url: http://mmisw.org/ont/cf/parameter/sea_water_practical_salinity
+      units: "1e-3"
+      coordinates: time z longitude latitude
+  sea_water_practical_salinity_qc_agg:
+    shape:
+      - time
+    type: int
+    attributes:
+      _FillValue: -9999
+      _ChunkSizes:
+        - 7240
+        - 1
+      _Unsigned: "true"
+      actual_range:
+        - 1
+        - 4
+      flag_meanings: PASS NOT_EVALUATED SUSPECT FAIL MISSING
+      flag_values:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 9
+      ioos_category: Other
+      long_name: Salinity QARTOD Aggregate Quality Flag
+      references: http://services.cormp.org/quality.php
+      standard_name: aggregate_quality_flag
+      coordinates: time z longitude latitude
+  sea_water_practical_salinity_qc_tests:
+    shape:
+      - time
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 7240
+        - 1
+      _Unsigned: "true"
+      comment: '11-character string with results of individual QARTOD tests. 1: Gap Test, 2: Syntax Test, 3: Location Test, 4: Gross Range Test, 5: Climatology Test, 6: Spike Test, 7: Rate of Change Test, 8: Flat-line Test, 9: Multi-variate Test, 10: Attenuated Signal Test, 11: Neighbor Test'
+      flag_meanings: PASS NOT_EVALUATED SUSPECT FAIL MISSING
+      flag_values:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 9
+      ioos_category: Other
+      long_name: Salinity QARTOD Individual Tests
+      references: http://services.cormp.org/quality.php
+      standard_name: sea_water_practical_salinity quality_flag
+      coordinates: time z longitude latitude
+  sea_water_temperature:
+    shape:
+      - time
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 7240
+        - 1
+      actual_range:
+        - 2.958
+        - 29.63
+      ancillary_variables: sea_water_temperature_qc_agg sea_water_temperature_qc_tests
+      id: "1000318"
+      ioos_category: Other
+      long_name: Water Temperature
+      platform: station
+      standard_name: sea_water_temperature
+      standard_name_url: http://mmisw.org/ont/cf/parameter/sea_water_temperature
+      units: degree_Celsius
+      coordinates: time z longitude latitude
+  sea_water_temperature_qc_agg:
+    shape:
+      - time
+    type: int
+    attributes:
+      _FillValue: -9999
+      _ChunkSizes:
+        - 7240
+        - 1
+      _Unsigned: "true"
+      actual_range:
+        - 1
+        - 4
+      flag_meanings: PASS NOT_EVALUATED SUSPECT FAIL MISSING
+      flag_values:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 9
+      ioos_category: Other
+      long_name: Water Temperature QARTOD Aggregate Quality Flag
+      references: http://services.cormp.org/quality.php
+      standard_name: aggregate_quality_flag
+      coordinates: time z longitude latitude
+  sea_water_temperature_qc_tests:
+    shape:
+      - time
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 7240
+        - 1
+      _Unsigned: "true"
+      comment: '11-character string with results of individual QARTOD tests. 1: Gap Test, 2: Syntax Test, 3: Location Test, 4: Gross Range Test, 5: Climatology Test, 6: Spike Test, 7: Rate of Change Test, 8: Flat-line Test, 9: Multi-variate Test, 10: Attenuated Signal Test, 11: Neighbor Test'
+      flag_meanings: PASS NOT_EVALUATED SUSPECT FAIL MISSING
+      flag_values:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 9
+      ioos_category: Other
+      long_name: Water Temperature QARTOD Individual Tests
+      references: http://services.cormp.org/quality.php
+      standard_name: sea_water_temperature quality_flag
+      coordinates: time z longitude latitude
+  station:
+    type: string
+    attributes:
+      cf_role: timeseries_id
+      long_name: (41029 / CAP2) Capers Nearshore
+      _Encoding: ISO-8859-1
+      ioos_category: Identifier
+      ioos_code: urn:ioos:station:com.axiomdatascience:60417
+      short_name: org_cormp_cap2
+      type: buoy
+  time:
+    shape:
+      - time
+    type: double
+    attributes:
+      units: seconds since 1970-01-01T00:00:00Z
+      standard_name: time
+      axis: T
+      _CoordinateAxisType: Time
+      actual_range:
+        - 1.53838128e+09
+        - 1.58558088e+09
+      calendar: gregorian
+      ioos_category: Time
+      long_name: Time
+      time_origin: 01-JAN-1970 00:00:00
+  wind_from_direction:
+    shape:
+      - time
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 7240
+        - 1
+      actual_range:
+        - 0
+        - 359.4
+      ancillary_variables: wind_from_direction_qc_agg wind_from_direction_qc_tests
+      id: "1000319"
+      ioos_category: Other
+      long_name: Wind From Direction
+      platform: station
+      standard_name: wind_from_direction
+      standard_name_url: http://mmisw.org/ont/cf/parameter/wind_from_direction
+      units: degrees
+      coordinates: time z longitude latitude
+  wind_from_direction_qc_agg:
+    shape:
+      - time
+    type: int
+    attributes:
+      _FillValue: -9999
+      _ChunkSizes:
+        - 7240
+        - 1
+      _Unsigned: "true"
+      actual_range:
+        - 1
+        - 4
+      flag_meanings: PASS NOT_EVALUATED SUSPECT FAIL MISSING
+      flag_values:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 9
+      ioos_category: Other
+      long_name: Wind From Direction QARTOD Aggregate Quality Flag
+      references: http://services.cormp.org/quality.php
+      standard_name: aggregate_quality_flag
+      coordinates: time z longitude latitude
+  wind_from_direction_qc_tests:
+    shape:
+      - time
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 7240
+        - 1
+      _Unsigned: "true"
+      comment: '11-character string with results of individual QARTOD tests. 1: Gap Test, 2: Syntax Test, 3: Location Test, 4: Gross Range Test, 5: Climatology Test, 6: Spike Test, 7: Rate of Change Test, 8: Flat-line Test, 9: Multi-variate Test, 10: Attenuated Signal Test, 11: Neighbor Test'
+      flag_meanings: PASS NOT_EVALUATED SUSPECT FAIL MISSING
+      flag_values:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 9
+      ioos_category: Other
+      long_name: Wind From Direction QARTOD Individual Tests
+      references: http://services.cormp.org/quality.php
+      standard_name: wind_from_direction quality_flag
+      coordinates: time z longitude latitude
+  wind_speed:
+    shape:
+      - time
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 7240
+        - 1
+      actual_range:
+        - 0
+        - 24.524128
+      ancillary_variables: wind_speed_qc_agg wind_speed_qc_tests
+      id: "1000320"
+      ioos_category: Other
+      long_name: Wind Speed
+      platform: station
+      standard_name: wind_speed
+      standard_name_url: http://mmisw.org/ont/cf/parameter/wind_speed
+      units: m.s-1
+      coordinates: time z longitude latitude
+  wind_speed_of_gust:
+    shape:
+      - time
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 7240
+        - 1
+      actual_range:
+        - 0
+        - 59.779812737936
+      ancillary_variables: wind_speed_of_gust_qc_agg wind_speed_of_gust_qc_tests
+      id: "1000321"
+      ioos_category: Other
+      long_name: Wind Gust
+      platform: station
+      standard_name: wind_speed_of_gust
+      standard_name_url: http://mmisw.org/ont/cf/parameter/wind_speed_of_gust
+      units: m.s-1
+      coordinates: time z longitude latitude
+  wind_speed_of_gust_qc_agg:
+    shape:
+      - time
+    type: int
+    attributes:
+      _FillValue: -9999
+      _ChunkSizes:
+        - 7240
+        - 1
+      _Unsigned: "true"
+      actual_range:
+        - 1
+        - 4
+      flag_meanings: PASS NOT_EVALUATED SUSPECT FAIL MISSING
+      flag_values:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 9
+      ioos_category: Other
+      long_name: Wind Gust QARTOD Aggregate Quality Flag
+      references: http://services.cormp.org/quality.php
+      standard_name: aggregate_quality_flag
+      coordinates: time z longitude latitude
+  wind_speed_of_gust_qc_tests:
+    shape:
+      - time
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 7240
+        - 1
+      _Unsigned: "true"
+      comment: '11-character string with results of individual QARTOD tests. 1: Gap Test, 2: Syntax Test, 3: Location Test, 4: Gross Range Test, 5: Climatology Test, 6: Spike Test, 7: Rate of Change Test, 8: Flat-line Test, 9: Multi-variate Test, 10: Attenuated Signal Test, 11: Neighbor Test'
+      flag_meanings: PASS NOT_EVALUATED SUSPECT FAIL MISSING
+      flag_values:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 9
+      ioos_category: Other
+      long_name: Wind Gust QARTOD Individual Tests
+      references: http://services.cormp.org/quality.php
+      standard_name: wind_speed_of_gust quality_flag
+      coordinates: time z longitude latitude
+  wind_speed_qc_agg:
+    shape:
+      - time
+    type: int
+    attributes:
+      _FillValue: -9999
+      _ChunkSizes:
+        - 7240
+        - 1
+      _Unsigned: "true"
+      actual_range:
+        - 1
+        - 4
+      flag_meanings: PASS NOT_EVALUATED SUSPECT FAIL MISSING
+      flag_values:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 9
+      ioos_category: Other
+      long_name: Wind Speed QARTOD Aggregate Quality Flag
+      references: http://services.cormp.org/quality.php
+      standard_name: aggregate_quality_flag
+      coordinates: time z longitude latitude
+  wind_speed_qc_tests:
+    shape:
+      - time
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 7240
+        - 1
+      _Unsigned: "true"
+      comment: '11-character string with results of individual QARTOD tests. 1: Gap Test, 2: Syntax Test, 3: Location Test, 4: Gross Range Test, 5: Climatology Test, 6: Spike Test, 7: Rate of Change Test, 8: Flat-line Test, 9: Multi-variate Test, 10: Attenuated Signal Test, 11: Neighbor Test'
+      flag_meanings: PASS NOT_EVALUATED SUSPECT FAIL MISSING
+      flag_values:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 9
+      ioos_category: Other
+      long_name: Wind Speed QARTOD Individual Tests
+      references: http://services.cormp.org/quality.php
+      standard_name: wind_speed quality_flag
+      coordinates: time z longitude latitude
+  z:
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      axis: Z
+      _CoordinateAxisType: Height
+      _CoordinateZisPositive: up
+      actual_range:
+        - 0
+        - 0
+      ioos_category: Location
+      long_name: Altitude
+      positive: up
+      standard_name: altitude
+      units: m
+attributes:
+  Conventions: IOOS-1.2, CF-1.6, ACDD-1.3
+  date_created: "2020-04-22T22:49:00Z"
+  featureType: TimeSeries
+  cdm_data_type: TimeSeries
+  cdm_timeseries_variables: station,longitude,latitude
+  contributor_email: None,,feedback@axiomdatascience.com
+  contributor_name: Southeast Coastal Ocean Observing Regional Association (SECOORA),World Meteorological Organization (WMO),Axiom Data Science
+  contributor_role: funder,contributor,processor
+  contributor_role_vocabulary: NERC
+  contributor_url: https://secoora.org/,https://www.wmo.int/pages/prog/amp/mmop/wmo-number-rules.html,https://www.axiomdatascience.com
+  creator_country: USA
+  creator_email: info@cormp.org
+  creator_institution: UNCW - Coastal Ocean Research and Monitoring Program (CORMP)
+  creator_name: UNCW - Coastal Ocean Research and Monitoring Program (CORMP)
+  creator_sector: gov_federal
+  creator_type: institution
+  creator_url: http://www.cormp.org/index.php
+  Easternmost_Easting: -79.6204
+  geospatial_lat_max: 32.8032
+  geospatial_lat_min: 32.8032
+  geospatial_lat_units: degrees_north
+  geospatial_lon_max: -79.6204
+  geospatial_lon_min: -79.6204
+  geospatial_lon_units: degrees_east
+  geospatial_vertical_positive: up
+  geospatial_vertical_units: m
+  history: |-
+    Downloaded from UNCW - Coastal Ocean Research and Monitoring Program (CORMP) at http://services.cormp.org/data.php?format=json&platform=cap2
+    2020-04-22T22:33:09Z http://services.cormp.org/data.php?format=json&platform=cap2
+    2020-04-22T22:33:09Z http://erddap.stage.sensors.axds.co/erddap/tabledap/org_cormp_cap2.nc
+  infoUrl: https://sensors.ioos.us/#metadata/60417/station
+  institution: UNCW - Coastal Ocean Research and Monitoring Program (CORMP)
+  license: |-
+    The data may be used and redistributed for free but is not intended
+    for legal use, since it may contain inaccuracies. Neither the data
+    Contributor, ERD, NOAA, nor the United States Government, nor any
+    of their employees or contractors, makes any warranty, express or
+    implied, including warranties of merchantability and fitness for a
+    particular purpose, or assumes any legal liability for the accuracy,
+    completeness, or usefulness, of this information.
+  Northernmost_Northing: 32.8032
+  platform_name: (41029 / CAP2) Capers Nearshore
+  platform_vocabulary: http://mmisw.org/ont/ioos/platform
+  processing_level: Level 2
+  publisher_country: USA
+  publisher_email: info@cormp.org
+  publisher_institution: UNCW - Coastal Ocean Research and Monitoring Program (CORMP)
+  publisher_name: UNCW - Coastal Ocean Research and Monitoring Program (CORMP)
+  publisher_sector: gov_federal
+  publisher_type: institution
+  publisher_url: http://www.cormp.org/index.php
+  references: http://www.cormp.org/?platform=CAP2,http://services.cormp.org/data.php?format=json&platform=cap2,http://mwp.secoora.org/?platform=41029,http://services.cormp.org/quality.php
+  sourceUrl: http://services.cormp.org/data.php?format=json&platform=cap2
+  Southernmost_Northing: 32.8032
+  standard_name_vocabulary: CF Standard Name Table v72
+  summary: Timeseries data from '(41029 / CAP2) Capers Nearshore' (org_cormp_cap2)
+  time_coverage_end: "2020-03-30T15:08:00Z"
+  time_coverage_start: "2018-10-01T08:08:00Z"
+  title: (41029 / CAP2) Capers Nearshore
+  Westernmost_Easting: -79.6204
+  wmo_platform_code: "41029"
+  id: cap2
+  naming_authority: org.cormp
+  platform: "41029"

--- a/datasets-yml/usf_comps_c10_inwater.nc.yml
+++ b/datasets-yml/usf_comps_c10_inwater.nc.yml
@@ -1,0 +1,409 @@
+dimensions:
+  time: 145
+  z: 24
+variables:
+  crs:
+    type: int
+  eastward_sea_water_velocity:
+    shape:
+      - time
+      - z
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 51050
+        - 8
+      actual_range:
+        - -0.194
+        - 0.2574
+      ancillary_variables: eastward_sea_water_velocity_qc_agg eastward_sea_water_velocity_qc_tests
+      id: "1001921"
+      ioos_category: Other
+      long_name: Eastward Sea Water Velocity
+      platform: station
+      standard_name: eastward_sea_water_velocity
+      standard_name_url: http://mmisw.org/ont/cf/parameter/eastward_sea_water_velocity
+      units: m.s-1
+      coordinates: time z longitude latitude
+  eastward_sea_water_velocity_qc_agg:
+    shape:
+      - time
+      - z
+    type: int
+    attributes:
+      _FillValue: -9999
+      _ChunkSizes:
+        - 153150
+        - 24
+      _Unsigned: "true"
+      flag_meanings: PASS NOT_EVALUATED SUSPECT FAIL MISSING
+      flag_values:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 9
+      ioos_category: Other
+      long_name: Eastward Sea Water Velocity QARTOD Aggregate Quality Flag
+      standard_name: aggregate_quality_flag
+      coordinates: time z longitude latitude
+  eastward_sea_water_velocity_qc_tests:
+    shape:
+      - time
+      - z
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 51050
+        - 8
+      _Unsigned: "true"
+      comment: '11-character string with results of individual QARTOD tests. 1: Gap Test, 2: Syntax Test, 3: Location Test, 4: Gross Range Test, 5: Climatology Test, 6: Spike Test, 7: Rate of Change Test, 8: Flat-line Test, 9: Multi-variate Test, 10: Attenuated Signal Test, 11: Neighbor Test'
+      flag_meanings: PASS NOT_EVALUATED SUSPECT FAIL MISSING
+      flag_values:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 9
+      ioos_category: Other
+      long_name: Eastward Sea Water Velocity QARTOD Individual Tests
+      standard_name: eastward_sea_water_velocity quality_flag
+      coordinates: time z longitude latitude
+  latitude:
+    type: double
+    attributes:
+      axis: Y
+      _CoordinateAxisType: Lat
+      actual_range:
+        - 27.173
+        - 27.173
+      ioos_category: Location
+      long_name: Latitude
+      standard_name: latitude
+      units: degrees_north
+  longitude:
+    type: double
+    attributes:
+      axis: X
+      _CoordinateAxisType: Lon
+      actual_range:
+        - -82.924
+        - -82.924
+      ioos_category: Location
+      long_name: Longitude
+      standard_name: longitude
+      units: degrees_east
+  northward_sea_water_velocity:
+    shape:
+      - time
+      - z
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 51050
+        - 8
+      actual_range:
+        - -0.2895
+        - 0.1591
+      ancillary_variables: northward_sea_water_velocity_qc_agg northward_sea_water_velocity_qc_tests
+      id: "1001922"
+      ioos_category: Other
+      long_name: Northward Sea Water Velocity
+      platform: station
+      standard_name: northward_sea_water_velocity
+      standard_name_url: http://mmisw.org/ont/cf/parameter/northward_sea_water_velocity
+      units: m.s-1
+      coordinates: time z longitude latitude
+  northward_sea_water_velocity_qc_agg:
+    shape:
+      - time
+      - z
+    type: int
+    attributes:
+      _FillValue: -9999
+      _ChunkSizes:
+        - 153150
+        - 24
+      _Unsigned: "true"
+      flag_meanings: PASS NOT_EVALUATED SUSPECT FAIL MISSING
+      flag_values:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 9
+      ioos_category: Other
+      long_name: Northward Sea Water Velocity QARTOD Aggregate Quality Flag
+      standard_name: aggregate_quality_flag
+      coordinates: time z longitude latitude
+  northward_sea_water_velocity_qc_tests:
+    shape:
+      - time
+      - z
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 51050
+        - 8
+      _Unsigned: "true"
+      comment: '11-character string with results of individual QARTOD tests. 1: Gap Test, 2: Syntax Test, 3: Location Test, 4: Gross Range Test, 5: Climatology Test, 6: Spike Test, 7: Rate of Change Test, 8: Flat-line Test, 9: Multi-variate Test, 10: Attenuated Signal Test, 11: Neighbor Test'
+      flag_meanings: PASS NOT_EVALUATED SUSPECT FAIL MISSING
+      flag_values:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 9
+      ioos_category: Other
+      long_name: Northward Sea Water Velocity QARTOD Individual Tests
+      standard_name: northward_sea_water_velocity quality_flag
+      coordinates: time z longitude latitude
+  sea_water_speed:
+    shape:
+      - time
+      - z
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 51050
+        - 8
+      actual_range:
+        - 0.002668
+        - 0.291263
+      ancillary_variables: sea_water_speed_qc_agg sea_water_speed_qc_tests
+      id: "1001924"
+      ioos_category: Other
+      long_name: Current Speed
+      platform: station
+      standard_name: sea_water_speed
+      standard_name_url: http://mmisw.org/ont/cf/parameter/sea_water_speed
+      units: m.s-1
+      coordinates: time z longitude latitude
+  sea_water_speed_qc_agg:
+    shape:
+      - time
+      - z
+    type: int
+    attributes:
+      _FillValue: -9999
+      _ChunkSizes:
+        - 153150
+        - 24
+      _Unsigned: "true"
+      flag_meanings: PASS NOT_EVALUATED SUSPECT FAIL MISSING
+      flag_values:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 9
+      ioos_category: Other
+      long_name: Current Speed QARTOD Aggregate Quality Flag
+      standard_name: aggregate_quality_flag
+      coordinates: time z longitude latitude
+  sea_water_speed_qc_tests:
+    shape:
+      - time
+      - z
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 51050
+        - 8
+      _Unsigned: "true"
+      comment: '11-character string with results of individual QARTOD tests. 1: Gap Test, 2: Syntax Test, 3: Location Test, 4: Gross Range Test, 5: Climatology Test, 6: Spike Test, 7: Rate of Change Test, 8: Flat-line Test, 9: Multi-variate Test, 10: Attenuated Signal Test, 11: Neighbor Test'
+      flag_meanings: PASS NOT_EVALUATED SUSPECT FAIL MISSING
+      flag_values:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 9
+      ioos_category: Other
+      long_name: Current Speed QARTOD Individual Tests
+      standard_name: sea_water_speed quality_flag
+      coordinates: time z longitude latitude
+  sea_water_velocity_to_direction:
+    shape:
+      - time
+      - z
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 51050
+        - 8
+      actual_range:
+        - 180.0429
+        - 359.97455
+      ancillary_variables: sea_water_velocity_to_direction_qc_agg sea_water_velocity_to_direction_qc_tests
+      id: "1001923"
+      ioos_category: Other
+      long_name: Current To Direction
+      platform: station
+      standard_name: sea_water_velocity_to_direction
+      standard_name_url: http://mmisw.org/ont/cf/parameter/sea_water_velocity_to_direction
+      units: degrees
+      coordinates: time z longitude latitude
+  sea_water_velocity_to_direction_qc_agg:
+    shape:
+      - time
+      - z
+    type: int
+    attributes:
+      _FillValue: -9999
+      _ChunkSizes:
+        - 153150
+        - 24
+      _Unsigned: "true"
+      flag_meanings: PASS NOT_EVALUATED SUSPECT FAIL MISSING
+      flag_values:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 9
+      ioos_category: Other
+      long_name: Current To Direction QARTOD Aggregate Quality Flag
+      standard_name: aggregate_quality_flag
+      coordinates: time z longitude latitude
+  sea_water_velocity_to_direction_qc_tests:
+    shape:
+      - time
+      - z
+    type: double
+    attributes:
+      _FillValue: -9999.9
+      _ChunkSizes:
+        - 51050
+        - 8
+      _Unsigned: "true"
+      comment: '11-character string with results of individual QARTOD tests. 1: Gap Test, 2: Syntax Test, 3: Location Test, 4: Gross Range Test, 5: Climatology Test, 6: Spike Test, 7: Rate of Change Test, 8: Flat-line Test, 9: Multi-variate Test, 10: Attenuated Signal Test, 11: Neighbor Test'
+      flag_meanings: PASS NOT_EVALUATED SUSPECT FAIL MISSING
+      flag_values:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 9
+      ioos_category: Other
+      long_name: Current To Direction QARTOD Individual Tests
+      standard_name: sea_water_velocity_to_direction quality_flag
+      coordinates: time z longitude latitude
+  station:
+    type: string
+    attributes:
+      cf_role: timeseries_id
+      long_name: 42013 - C10 Currents - WFS Central Buoy
+      _Encoding: ISO-8859-1
+      ioos_category: Identifier
+      ioos_code: urn:ioos:station:com.axiomdatascience:100702
+      short_name: 42013-c10-currents-wfs-centra
+      type: buoy
+  time:
+    shape:
+      - time
+    type: double
+    attributes:
+      units: seconds since 1970-01-01T00:00:00Z
+      standard_name: time
+      axis: T
+      _CoordinateAxisType: Time
+      actual_range:
+        - 1.5198624e+09
+        - 1.5203808e+09
+      calendar: gregorian
+      cf_role: profile_id
+      ioos_category: Time
+      long_name: Time
+      time_origin: 01-JAN-1970 00:00:00
+  z:
+    shape:
+      - z
+    type: double
+    attributes:
+      axis: Z
+      _CoordinateAxisType: Height
+      _CoordinateZisPositive: up
+      actual_range:
+        - -22
+        - -3
+      ioos_category: Location
+      long_name: Altitude
+      positive: up
+      standard_name: altitude
+      units: m
+attributes:
+  Conventions: IOOS-1.2, CF-1.6, ACDD-1.3
+  date_created: "2020-04-22T22:51:00Z"
+  featureType: TimeSeriesProfile
+  cdm_data_type: TimeSeriesProfile
+  cdm_altitude_proxy: z
+  cdm_profile_variables: time
+  cdm_timeseries_variables: station,longitude,latitude
+  contributor_email: ',None,feedback@axiomdatascience.com'
+  contributor_name: World Meteorological Organization (WMO),Southeast Coastal Ocean Observing Regional Association (SECOORA),Axiom Data Science
+  contributor_role: contributor,funder,processor
+  contributor_role_vocabulary: NERC
+  contributor_url: https://www.wmo.int/pages/prog/amp/mmop/wmo-number-rules.html,https://secoora.org/,https://www.axiomdatascience.com
+  creator_country: USA
+  creator_email: cmerz@usf.edu
+  creator_institution: USF CMS - Coastal Ocean Monitoring and Prediction System (COMPS)
+  creator_name: USF CMS - Coastal Ocean Monitoring and Prediction System (COMPS)
+  creator_sector: academic
+  creator_type: institution
+  creator_url: http://comps.marine.usf.edu/
+  Easternmost_Easting: -82.924
+  geospatial_lat_max: 27.173
+  geospatial_lat_min: 27.173
+  geospatial_lat_units: degrees_north
+  geospatial_lon_max: -82.924
+  geospatial_lon_min: -82.924
+  geospatial_lon_units: degrees_east
+  geospatial_vertical_positive: up
+  geospatial_vertical_units: m
+  history: |-
+    Downloaded from USF CMS - Coastal Ocean Monitoring and Prediction System (COMPS) at http://comps.marine.usf.edu:82/data.php?format=json&platform=c10_inwater
+    2020-04-22T22:51:03Z http://comps.marine.usf.edu:82/data.php?format=json&platform=c10_inwater
+    2020-04-22T22:51:03Z http://erddap.stage.sensors.axds.co/erddap/tabledap/42013-c10-currents-wfs-centra.nc?&time%3E=2018-03-01T00:00:00Z&time%3C=2018-03-07T00:00:00Z
+  infoUrl: https://sensors.ioos.us/#metadata/100702/station
+  institution: USF CMS - Coastal Ocean Monitoring and Prediction System (COMPS)
+  license: |-
+    The data may be used and redistributed for free but is not intended
+    for legal use, since it may contain inaccuracies. Neither the data
+    Contributor, ERD, NOAA, nor the United States Government, nor any
+    of their employees or contractors, makes any warranty, express or
+    implied, including warranties of merchantability and fitness for a
+    particular purpose, or assumes any legal liability for the accuracy,
+    completeness, or usefulness, of this information.
+  Northernmost_Northing: 27.173
+  platform_name: 42013 - C10 Currents - WFS Central Buoy
+  platform_vocabulary: http://mmisw.org/ont/ioos/platform
+  processing_level: Level 2
+  publisher_country: USA
+  publisher_email: cmerz@usf.edu
+  publisher_institution: USF CMS - Coastal Ocean Monitoring and Prediction System (COMPS)
+  publisher_name: USF CMS - Coastal Ocean Monitoring and Prediction System (COMPS)
+  publisher_sector: academic
+  publisher_type: institution
+  publisher_url: http://comps.marine.usf.edu/
+  references: http://comps.marine.usf.edu/index?view=station&id=C10_INWATER,http://comps.marine.usf.edu:82/data.php?format=json&platform=c10_inwater,
+  sourceUrl: http://comps.marine.usf.edu:82/data.php?format=json&platform=c10_inwater
+  Southernmost_Northing: 27.173
+  standard_name_vocabulary: CF Standard Name Table v72
+  station_id: 100702
+  summary: Timeseries data from '42013 - C10 Currents - WFS Central Buoy' (42013-c10-currents-wfs-centra)
+  time_coverage_end: "2018-03-07T00:00:00Z"
+  time_coverage_start: "2018-03-01T00:00:00Z"
+  title: 42013 - C10 Currents - WFS Central Buoy
+  Westernmost_Easting: -82.924
+  wmo_platform_code: "42013"
+  id: c10_inwater
+  naming_authority: usf.comps
+  platform: "42013"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       ERDDAP_MIN_MEMORY: 1G
       ERDDAP_MAX_MEMORY: 2G
       ERDDAP_bigParentDirectory: /erddapData/
-      ERDDAP_baseUrl: http://localhost:8080
+      ERDDAP_baseUrl: "${ERDDAP_baseUrl:-http://localhost:8080}"
       ERDDAP_baseHttpsUrl: https://localhost:8080
       ERDDAP_flagKeyKey: change-this-value!!
       ERDDAP_emailEverythingT: this+goes+nowhere@doesnotexist.ioos.us


### PR DESCRIPTION
As an alternate approach to using nccsv source of truth datasets in #51, instead we store text yaml representations of the gold standard datasets based on nco-json output (nco-yaml if you will, which is more readable than json due to lack of brackets).

Also included is a script to easily (re-)generate the yaml representations from the source of truth NetCDF files, and to check if the yaml representations are up to date (possibly used in a future pre-commit hook, GitHub action, etc).