### PR TITLE
Updated docker run command to match docker-compose.yml

### DIFF
--- a/_docs/index.md
+++ b/_docs/index.md
@@ -62,8 +62,6 @@ $ ls -Ap
       -v $(pwd)/erddap/content:/usr/local/tomcat/content/erddap \
       -v $(pwd)/erddap/data:/erddapData \
       -v $(pwd)/datasets:/datasets \
-      -v /tmp/:/usr/local/tomcat/temp/ \
-      --env ERDDAP_MIN_MEMORY=1G --env ERDDAP_MAX_MEMORY=2G \
      axiom/docker-erddap:2.23-jdk17-openjdk
     ```
     get `axiom/docker-erddap:2.23-jdk17-openjdk` or the latest one available from [axiom docker-erddap](https://github.com/axiom-data-science/docker-erddap).


### PR DESCRIPTION
This is a minor update to the GitHub Pages/Jekyll markdown to work with the changes to `docker run` example proposed in PR #67.  