### PR TITLE
add GHA to convert CDL <-> NC

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# See https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "Bot"

--- a/.github/workflows/convert_cdl_nc_cdl.yml
+++ b/.github/workflows/convert_cdl_nc_cdl.yml
@@ -1,0 +1,26 @@
+name: Check NC <->C DL
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup Micromamba Python
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-name: GHA
+        init-shell: bash
+        create-args: >-
+          python=3 netcdf4 --channel conda-forge
+
+    - name: Convert NC files to CDL and back
+      shell: bash -l {0}
+      run: |
+        python convert_nc_cdl.py

--- a/.github/workflows/convert_cdl_nc_cdl.yml
+++ b/.github/workflows/convert_cdl_nc_cdl.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   run:
@@ -24,3 +25,27 @@ jobs:
       shell: bash -l {0}
       run: |
         python convert_nc_cdl.py
+
+    - name: Get current date
+      run: echo "NOW=$(date -u)" >> ${GITHUB_ENV}
+
+    - name: Create Pull Request
+      if: github.ref == 'refs/heads/main'
+      id: cpr
+      uses: peter-evans/create-pull-request@v6
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: "Latest data: ${{ env.NOW }}"
+        branch: update-gold-standard-files
+        delete-branch: true
+        title: "[file-conversion-ci] update gold standard file"
+        body: |
+          Update gold-standard files.
+        labels: |
+          Bot
+
+    - name: Check outputs
+      if: ${{ steps.cpr.outputs.pull-request-number }}
+      run: |
+        echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+        echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/convert_nc_cdl.py
+++ b/convert_nc_cdl.py
@@ -1,0 +1,30 @@
+from netCDF4 import Dataset
+
+
+def convert_nc_to_cdl(nc_fname):
+    cdl_fname = nc_fname.with_suffix(".cdl")
+    if cdl_fname.exists():
+        print(f"The {cdl_fname} file already exists, not overwriting it.")
+        return
+    with Dataset(nc_fname) as nc:
+        print(f"Converting {nc_fname} to {cdl_fname}.")
+        nc.tocdl(coordvars=True, data=True, outfile=cdl_fname)
+
+def convert_cdl_to_nc(cdl_name):
+    nc_fname = cdl_fname.with_suffix(".nc")
+    if nc_fname.exists():
+        print(f"The {nc_fname} file already exists, not overwriting it.")
+        return
+    print(f"Converting {cdl_fname} to {nc_fname}.")
+    Dataset.fromcdl(cdl_fname)
+
+
+if __name__ == "__main__":
+    from pathlib import Path
+    
+    datasets_path = Path("datasets")
+    for nc_fname in datasets_path.glob("*.nc"):
+        convert_nc_to_cdl(nc_fname)
+    
+    for cdl_fname in datasets_path.glob("*.cdl"):
+        convert_cdl_to_nc(cdl_fname)


### PR DESCRIPTION
- [X] Convert `.nc` files in the datasets folder to and from `.cdl` if the one or the other is not present.
- [X] Add dependabot to keep the GitHub Action updated.
- [ ] Add a commit new file option [1].


Below is how the file tree will look like with this option. A Diffable CDL and the binary netCDF4 file. Contributor can commit one or the other and this GitHub Action will prepare the missing part. The decision we need to make on [1] is:

a. We amend the contributor PR with the new file: Elegant, few PRs, but can lead to confusion b/c we will be writing over something that is probably in flux and some contributors are not too familiar with GitHub to work that out.
b. Send a fresh PR from main so the pending file will be added as soon as the PR adding the file was merged.
c. Do not add any file, just fail the PR and ask the contributor to convert and commit it.

I'm inclined to `b` or `c`.


```
.
├── ArchiveADataset.sh
├── convert_nc_cdl.py
├── DasDds.sh
├── datasets
│   ├── edu_calpoly_marine_morro_bay_met.cdl
│   ├── edu_calpoly_marine_morro_bay_met.nc
│   ├── org_cormp_cap2.cdl
│   ├── org_cormp_cap2.nc
│   ├── usf_comps_c10_inwater.cdl
│   └── usf_comps_c10_inwater.nc
├── docker-compose.yml
├── erddap
│   ├── conf
│   │   ├── config.sh
│   │   └── robots.txt
│   └── content
│       ├── datasets.xml
│       ├── images
│       │   └── erddap2.css
│       └── setup.xml
├── erddap_utils.sh
├── GenerateDatasetsXml.sh
└── README.md
```