### PR TITLE
Pass arguments to GenerateDatasetsXml.sh

### DIFF
--- a/GenerateDatasetsXml.sh
+++ b/GenerateDatasetsXml.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
+ARGS="$@"
+
 docker run --rm -it \
   -v "$(pwd)/datasets:/datasets" \
   -v "$(pwd)/logs:/erddapData/logs" \
    -v $(pwd)/erddap/content:/usr/local/tomcat/content/erddap \
   axiom/docker-erddap:2.23-jdk17-openjdk \
-  bash -c "cd webapps/erddap/WEB-INF/ && bash GenerateDatasetsXml.sh -verbose"
+  bash -c "cd webapps/erddap/WEB-INF/ && bash GenerateDatasetsXml.sh -verbose $ARGS"


### PR DESCRIPTION
If you want to script GenerateDatasets.Xml, you need to pass args instead of entering info manually.  I suppose is a script it'd be easy to just call the docker directly, but this small change allows argument passing from this shell script.