### PR TITLE
Update the docker-compose.yml to be consistent with the docker commands in the guide

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
+      - /erddap/conf/config.sh:/usr/local/tomcat/bin/config.sh
       - ./erddap/conf/robots.txt:/usr/local/tomcat/webapps/ROOT/robots.txt
       - ./erddap/content:/usr/local/tomcat/content/erddap
       - ./erddap/data:/erddapData

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - /erddap/conf/config.sh:/usr/local/tomcat/bin/config.sh
+      - ./erddap/conf/config.sh:/usr/local/tomcat/bin/config.sh
       - ./erddap/conf/robots.txt:/usr/local/tomcat/webapps/ROOT/robots.txt
       - ./erddap/content:/usr/local/tomcat/content/erddap
       - ./erddap/data:/erddapData


### PR DESCRIPTION
Updated the docker-compose.yml to include the `config.sh` environment variables file when you use `docker-compose up -d` so it's available to be read from. 

You get errors if you have an **ERDDAP_adminPhone** as anything other than an integer, so I'm not sure at this point if it would be easier to just edit the `setup.xml` file in `erddap/content/` in lieu of using the `config.sh` file to set environment variables.