### PR TITLE
document public ERDDAP deployment using environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ follow these simple steps:
   ERDDAP_baseHttpsUrl environment variables inside the container. Sensible
   defaults keep localhost behavior working without any changes.
 
-- Make sure DNS for your domain points to the machine running the container.
+- Make sure DNS for your domain resolves to a publicly accessible IP address
+  that routes requests to the machine running the container (for example,
+  via firewall NAT directly to ERDDAP or through a reverse proxy).
   If the machine is behind a router, configure port forwarding for the ports
   you chose (for example, 80/443 or a custom port) to the host running the
   container.

--- a/README.md
+++ b/README.md
@@ -9,3 +9,38 @@ Uses the [ERDDAP Docker image](https://github.com/axiom-data-science/docker-erdd
 You can view this setup live at <https://standards.sensors.ioos.us/erddap/index.html>.
 
 Documentation can be found at <https://ioos.github.io/erddap-gold-standard/>.
+
+## Making ERDDAP Publicly Accessible
+
+This repository's Docker compose file is configured to work on localhost by
+default. To make ERDDAP reachable from a public IP address or domain name,
+follow these simple steps:
+
+- Set the host and ports used to build ERDDAP's public URLs. You can do this
+  by creating a `.env` file in the same directory as `docker-compose.yml` or
+  by exporting the variables in your shell before running `docker-compose up`.
+
+  Example `.env` (replace with your public domain or IP):
+
+  ERDDAP_HOST=example.org
+  HOST_HTTP_PORT=8080
+  HOST_HTTPS_PORT=443
+
+  The compose file uses these values to set the ERDDAP_baseUrl and
+  ERDDAP_baseHttpsUrl environment variables inside the container. Sensible
+  defaults keep localhost behavior working without any changes.
+
+- Make sure DNS for your domain points to the machine running the container.
+  If the machine is behind a router, configure port forwarding for the ports
+  you chose (for example, 80/443 or a custom port) to the host running the
+  container.
+
+- Use HTTPS in production. Obtain and install a TLS certificate (for example,
+  via Let's Encrypt) for your domain. You can terminate TLS at a reverse
+  proxy (nginx, Traefik, Caddy) in front of the ERDDAP container, or configure
+  a proxy service to forward HTTPS to the container's HTTP port. ERDDAP itself
+  should be left unchanged.
+
+For more detailed ERDDAP deployment guidance (security, reverse proxies,
+certificates and recommended production practices), see the upstream ERDDAP
+documentation: https://coastwatch.pfeg.noaa.gov/erddap/

--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ follow these simple steps:
 
 For more detailed ERDDAP deployment guidance (security, reverse proxies,
 certificates and recommended production practices), see the upstream ERDDAP
-documentation: https://coastwatch.pfeg.noaa.gov/erddap/
+documentation: https://erddap.github.io/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ Documentation can be found at <https://ioos.github.io/erddap-gold-standard/>.
 
 ## Making ERDDAP Publicly Accessible
 
+### URL Construction Behavior
+
+As of ERDDAP 2.28.0, `useHeadersForUrl` defaults to `true`. When enabled, ERDDAP
+uses the incoming request’s `Host` and protocol headers to construct URLs,
+assuming a correctly configured reverse proxy.
+
+The `ERDDAP_baseUrl` and `ERDDAP_baseHttpsUrl` settings are still used when ERDDAP
+generates URLs outside the context of an HTTP request (for example, in emailed
+reports or background tasks).
+
 This repository's Docker compose file is configured to work on localhost by
 default. To make ERDDAP reachable from a public IP address or domain name,
 follow these simple steps:

--- a/README.md
+++ b/README.md
@@ -30,11 +30,10 @@ follow these simple steps:
   by creating a `.env` file in the same directory as `docker-compose.yml` or
   by exporting the variables in your shell before running `docker-compose up`.
 
-  Example `.env` (replace with your public domain or IP):
+Example .env (replace with your public domain or IP):
 
-  ERDDAP_HOST=example.org
-  HOST_HTTP_PORT=8080
-  HOST_HTTPS_PORT=443
+ERDDAP_baseUrl=http://example.org:8080
+ERDDAP_baseHttpsUrl=https://example.org:8443
 
   The compose file uses these values to set the ERDDAP_baseUrl and
   ERDDAP_baseHttpsUrl environment variables inside the container. Sensible

--- a/README.md
+++ b/README.md
@@ -46,12 +46,16 @@ follow these simple steps:
   If the machine is behind a router, configure port forwarding for the ports
   you chose (for example, 80/443 or a custom port) to the host running the
   container.
-
 - Use HTTPS in production. Obtain and install a TLS certificate (for example,
-  via Let's Encrypt) for your domain. You can terminate TLS at a reverse
-  proxy (nginx, Traefik, Caddy) in front of the ERDDAP container, or configure
-  a proxy service to forward HTTPS to the container's HTTP port. ERDDAP itself
-  should be left unchanged.
+  via Let's Encrypt) for your domain. Typical deployment scenarios include:
+  - Terminating TLS at a reverse proxy (nginx, Traefik, Caddy) and proxying
+    requests to ERDDAP’s HTTP port
+  - Directly routing traffic to ERDDAP’s HTTP/HTTPS ports, typically via
+    firewall NAT
+  - Forwarding requests to ERDDAP at the web server, using HTTPS→HTTPS or
+    HTTP→HTTP (or redirecting HTTP to HTTPS)
+
+  ERDDAP itself should be left unchanged.
 
 For more detailed ERDDAP deployment guidance (security, reverse proxies,
 certificates and recommended production practices), see the upstream ERDDAP

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,8 @@ services:
     image: axiom/docker-erddap:2.23-jdk17-openjdk
     restart: unless-stopped
     ports:
-      - "${HOST_HTTP_PORT:-8080}:8080"
+      - "${ERDDAP_HTTP_PORT:-8080}:8080"
+      - "${ERDDAP_HTTPS_PORT:-8443}:8443"
     volumes:
       - ./erddap/conf/robots.txt:/usr/local/tomcat/webapps/ROOT/robots.txt
       - ./erddap/content:/usr/local/tomcat/content/erddap

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,11 +17,8 @@ services:
       # Host and port used to construct public URLs. These can be set in an
       # environment file (.env) or exported in your shell before running
       # docker-compose. Sensible defaults keep localhost behavior unchanged.
-      ERDDAP_HOST: ${ERDDAP_HOST:-localhost}
-      HOST_HTTP_PORT: ${HOST_HTTP_PORT:-8080}
-      HOST_HTTPS_PORT: ${HOST_HTTPS_PORT:-8080}
-      ERDDAP_baseUrl: http://${ERDDAP_HOST}:${HOST_HTTP_PORT}
-      ERDDAP_baseHttpsUrl: https://${ERDDAP_HOST}:${HOST_HTTPS_PORT}
+      ERDDAP_baseUrl: ${ERDDAP_baseUrl:-http://localhost:8080}
+      ERDDAP_baseHttpsUrl: ${ERDDAP_baseHttpsUrl}
       ERDDAP_flagKeyKey: change-this-value!!
       ERDDAP_emailEverythingTo: this+goes+nowhere@doesnotexist.ioos.us
       ERDDAP_emailDailyReportTo:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: axiom/docker-erddap:2.23-jdk17-openjdk
     restart: unless-stopped
     ports:
-      - "8080:8080"
+      - "${HOST_HTTP_PORT:-8080}:8080"
     volumes:
       - ./erddap/conf/robots.txt:/usr/local/tomcat/webapps/ROOT/robots.txt
       - ./erddap/content:/usr/local/tomcat/content/erddap
@@ -14,8 +14,14 @@ services:
       ERDDAP_MIN_MEMORY: 1G
       ERDDAP_MAX_MEMORY: 2G
       ERDDAP_bigParentDirectory: /erddapData/
-      ERDDAP_baseUrl: http://localhost:8080
-      ERDDAP_baseHttpsUrl: https://localhost:8080
+      # Host and port used to construct public URLs. These can be set in an
+      # environment file (.env) or exported in your shell before running
+      # docker-compose. Sensible defaults keep localhost behavior unchanged.
+      ERDDAP_HOST: ${ERDDAP_HOST:-localhost}
+      HOST_HTTP_PORT: ${HOST_HTTP_PORT:-8080}
+      HOST_HTTPS_PORT: ${HOST_HTTPS_PORT:-8080}
+      ERDDAP_baseUrl: http://${ERDDAP_HOST}:${HOST_HTTP_PORT}
+      ERDDAP_baseHttpsUrl: https://${ERDDAP_HOST}:${HOST_HTTPS_PORT}
       ERDDAP_flagKeyKey: change-this-value!!
       ERDDAP_emailEverythingTo: this+goes+nowhere@doesnotexist.ioos.us
       ERDDAP_emailDailyReportTo:


### PR DESCRIPTION
This PR adds documentation explaining how to make an ERDDAP deployment publicly accessible using environment variables.

It describes how to configure host and port values, outlines DNS and port-forwarding requirements, and provides guidance on using HTTPS in production. Default localhost behavior is preserved, and no ERDDAP internal logic or Docker behavior is changed.