### PR TITLE
Fix hash for the pinned version

### DIFF
--- a/.github/workflows/convert_cdl_nc_cdl.yml
+++ b/.github/workflows/convert_cdl_nc_cdl.yml
@@ -16,7 +16,7 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231 # v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
         persist-credentials: false

--- a/.github/workflows/sync_theme.yml
+++ b/.github/workflows/sync_theme.yml
@@ -20,7 +20,7 @@ jobs:
       contents: write
     steps:
     - name: Checkout repo
-      uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231 # v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: gh-pages
         fetch-depth: 0


### PR DESCRIPTION
Something is amiss with #103, this restores the proper hash for the latest release.  My guess is that dependabot got confused with the hash and version not matching and decided to bump to the latest commit instead.